### PR TITLE
Rough version of a uri validator/suggetion engine

### DIFF
--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -145,7 +145,7 @@ defmodule BroadwayRabbitMQ.AmqpClient do
   end
 
   defp validate_supported_opts("amqp" <> _ = uri, :connection, _supported_opts) do
-    {:ok, uri}
+    validate_uri_options(uri)
   end
 
   defp validate_supported_opts(opts, group_name, supported_opts) do
@@ -157,4 +157,192 @@ defmodule BroadwayRabbitMQ.AmqpClient do
       keys -> {:error, "Unsupported options #{inspect(keys)} for #{inspect(group_name)}"}
     end
   end
+
+  defp validate_uri_options("amqps" <> _ = uri) do
+    uri_query = case URI.parse(uri) do
+                   %URI{query: nil}   -> nil
+                   %URI{query: query} -> query |> URI.decode_query()
+                end
+
+    case uri |> to_charlist() |> :amqp_uri.parse() do
+      {:ok,
+        {:amqp_params_network, _username, _password,
+        _vhost, _location, _port,
+        channel_max, frame_max,
+        heartbeat, connection_timeout,tls_options,
+        _functions_for_erlang_module, _, _}} -> validate_uri_options(%{
+                                                  channel_max: channel_max,
+                                                  frame_max: frame_max,
+                                                  heartbeat: heartbeat,
+                                                  connection_timeout: connection_timeout,
+                                                  tls_options: tls_options},
+                                                  uri_query, uri)
+      {:error, error}                        -> {:error, error}
+    end
+  end
+
+  defp validate_uri_options("amqp" <> _ = uri ) do
+    uri_query = case URI.parse(uri) do
+                   %URI{query: nil}   -> nil
+                   %URI{query: query} -> query |> URI.decode_query()
+                end
+
+    case uri |> to_charlist() |> :amqp_uri.parse() do
+    {:ok,
+      {:amqp_params_network, _username, _password,
+      _vhost, _location, _port,
+      channel_max, frame_max,
+      heartbeat, connection_timeout, :none,
+      _functions_for_erlang_module, _, _ }} -> validate_uri_options(%{
+                                                channel_max: channel_max,
+                                                frame_max: frame_max,
+                                                heartbeat: heartbeat,
+                                                connection_timeout: connection_timeout,
+                                                tls_options: :none}, uri_query, uri)
+    {:error, error}                        -> {:error, error}
+    end
+  end
+
+  ###
+  #  Quick exit if there are no options to check
+  ###
+
+  defp validate_uri_options(_, nil, uri) do
+    {:ok, uri}
+  end
+
+  ###
+  # If you supply tls options over the ampq protocol :amqp dumps them silently
+  # but if you supply it ampqs protocol without tls options :amqp kicks out a
+  # useful warning. This is part is designed to check a typo in a more obvious
+  # fashion.
+  ###
+
+
+  defp validate_uri_options(%{tls_options: :none} = options, %{"cacertfile" => _} = uri_query, uri) do
+    warn_tls_config_over_unsecure()
+    remaining_uri_query = Map.delete(uri_query, "cacertfile")
+    validate_uri_options(options,remaining_uri_query, uri)
+  end
+
+  defp validate_uri_options(%{tls_options: :none} = options, %{"certfile" => _} = uri_query, uri) do
+    warn_tls_config_over_unsecure()
+    remaining_uri_query = Map.delete(uri_query, "certfile")
+    validate_uri_options(options, remaining_uri_query, uri)
+  end
+
+  defp validate_uri_options(%{tls_options: :none} = options, %{"server_name_indication" => _} = uri_query, uri) do
+    warn_tls_config_over_unsecure()
+    remaining_uri_query = Map.delete(uri_query, "server_name_indication")
+    validate_uri_options(options, remaining_uri_query, uri)
+  end
+
+  defp validate_uri_options(%{tls_options: :none} = options, %{"keyfile" => _} = uri_query, uri) do
+    warn_tls_config_over_unsecure()
+    remaining_uri_query = Map.delete(uri_query, "keyfile")
+    validate_uri_options(options, remaining_uri_query, uri)
+  end
+
+  defp validate_uri_options(%{tls_options: :none} = options, %{"verify" => _} = uri_query, uri) do
+    warn_tls_config_over_unsecure()
+    remaining_uri_query = Map.delete(uri_query, "verify")
+    validate_uri_options(options, remaining_uri_query, uri)
+  end
+
+  #######
+  # This catches an odd behavoir that will allow you to register more or less
+  # any option to verify, e.g. verify_some, but only two will actually do the
+  # job.
+  ######
+
+  defp validate_uri_options(%{tls_options: tls_options} = options, uri_query, uri) when is_list(tls_options) do
+    verify = Keyword.get(tls_options, :verify)
+    validate_verify_tls_option(verify)
+    post_tls_options = Map.delete(options, :tls_options)
+    validate_uri_options(post_tls_options, uri_query, uri)
+  end
+
+  ######
+  # Checks remaining keys and trys to make suggestions for typos
+  ######
+
+  defp validate_uri_options(_options, uri_query, uri) do
+    valid_uri_options_list = ["", #this catches extra & that :amqp ignores
+                              "channel_max",
+                              "connection_timeout",
+                              "frame_max",
+                              "heartbeat",
+                              "cacertfile",
+                              "certfile",
+                              "server_name_indication",
+                              "keyfile",
+                              "verify"
+                             ]
+
+
+    unknown_uri_params = remove_known_uri_keys(valid_uri_options_list, uri_query) |> Map.to_list()
+
+    test_remaining_options(valid_uri_options_list |> tl, unknown_uri_params, uri)
+  end
+
+
+  defp test_remaining_options(known_uri_params, [unknown_param | rest], uri) do
+
+    rated_list = for {key, _value} <- [unknown_param],
+                     uri_param <- known_uri_params do
+                     {uri_param, key, String.jaro_distance(uri_param, key)}
+                 end
+
+    {real_option, you_said, _} = rated_list
+                                 |> List.keysort(2)
+                                 |> List.last()
+
+    did_you_mean_warning(you_said, real_option)
+
+
+    test_remaining_options(known_uri_params, rest, uri)
+  end
+
+  defp test_remaining_options(_, [], uri) do
+    {:ok, uri}
+  end
+
+  defp remove_known_uri_keys([head | tail], uri_query) do
+    remove_known_uri_keys(tail, Map.delete(uri_query, head))
+  end
+
+  defp remove_known_uri_keys([], uri_query) do
+    uri_query
+  end
+
+  defp warn_tls_config_over_unsecure() do
+    Logger.warn("You passed tls options to an unsecure protocol(ampq://).If you want to use tls then please specify amqps://")
+  end
+
+  defp validate_verify_tls_option(:verify_none) do
+    :ok
+  end
+
+  defp validate_verify_tls_option(:verify_peer) do
+    :ok
+  end
+
+  defp validate_verify_tls_option(unknown_option) do
+    verify_peer_distance = Atom.to_string(unknown_option) |> String.jaro_distance("verify_peer")
+    verify_none_distance = Atom.to_string(unknown_option) |> String.jaro_distance("verify_none")
+    return_warning_for_verify_tls_option(verify_none_distance,verify_peer_distance, unknown_option)
+  end
+
+  defp return_warning_for_verify_tls_option(verify_peer, verify_none, unknown_option) when verify_peer > verify_none do
+    Logger.warn("You set your tls option verify as #{inspect(unknown_option)} did you mean #{:verify_peer}?")
+  end
+
+  defp return_warning_for_verify_tls_option(verify_peer, verify_none, unknown_option) when verify_peer < verify_none do
+    Logger.warn("You set your tls option verify as #{inspect(unknown_option)} did you mean #{:verify_none}?")
+  end
+
+  defp did_you_mean_warning(you_said, did_you_mean) do
+    Logger.warn("You attempted to pass #{inspect(you_said)} as an option did you mean #{inspect(did_you_mean)}?")
+  end
+
 end


### PR DESCRIPTION
So this was a little larger than I thought . :P 

But in general this attempts to solve the problem that the amqp library has a few behaviours that a mildly typo unfriendly. Chiefly ignoring URI params if it doesn't understand them. Which is fine but it wasn't to difficult to toss up a warning if there or accidents.

The code however is starting to hit a point where I feel like I am barrier of breaking this out to a validator module that can check both types of ways of connecting. 

Thoughts? @msaraiva or @dch  